### PR TITLE
v0.0.4 - switch to search based behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.elc
+/scratch.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# CHANGELOG for auth-source-gopass
+
+_newest tag first, each tag sorted in chronological order (oldest first)_
+
+## v0.0.4 (2025-07-05)
+Switch from path based key lookup where the caller needs to know the whole path to a search based workflow. 
+
+### Breaking Changes
+- `auth-source-gopass-construct-query-path` removed: this is now done by searching
+- The `user` is taken from the gopass secret, the secret's path, or the passed parameter of the user (in this order). Before it always was the passed in parameter.
+- Switching to use `gopass find` may find more secrets. E.g. The query for the user `name` will now also find the users `myname` and `misnamer`
+
+### Changes
+
+*  Add Melpa Badge (/Markus M. May <160079+triplem@users.noreply.github.com>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/c9f7dc4da6178ca122e488e9ea07f20ccd29d87e)
+*  fix: correctly handle not found secrets (/Jens Neuhalfen <jens@neuhalfen.name>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/9cd22a0dc183226d57677358c6782a4c769111c6)
+*  feat: use dedicated *gopass* buffer for debugging (/Jens Neuhalfen <jens@neuhalfen.name>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/b5503f95235ff22b9858211b1605eda58011e12a)
+*  fix: actually return nil when gopass is not found (/Jens Neuhalfen <jens@neuhalfen.name>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/065dea9153a559729ac82eded30d97cfe7510901)
+*  fix: actually return the password.. (/Jens Neuhalfen <jens@neuhalfen.name>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/52440313e7fbc7baa7efb0dc6d2d0a85efc29c7f)
+*  feat: add fn to find all candidates for the query (/Jens Neuhalfen <jens@neuhalfen.name>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/40397df97b47968b2822daaa1b15ecdf866ecf93)
+*  feat: add parser for secrets to extract username (/Jens Neuhalfen <jens@neuhalfen.name>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/e4fe58d1267635555e694854dfd748f86911a164)
+*  feat(get-secret): extract fallback user from path (/Jens Neuhalfen <jens@neuhalfen.name>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/1a164ae0c8d908330a45fa548d02b1173e2d3786)
+*  feat: switch to a search based approach (/Jens Neuhalfen <jens@neuhalfen.name>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/13ffb7b26617799e82a826c01933484455851b04)
+*  feat: add changelog builder (/Jens Neuhalfen <jens@neuhalfen.name>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/565d4d40c29b0e803284c3f2e81bab4a49635237)
+*  feat: remove now unused `...-construct-query-path` (/Jens Neuhalfen <jens@neuhalfen.name>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/cab5207a188e5224c6131ba3ffbca6064cc0a53d)
+*  fix: respect auth-source-gopass-path-separator (/Jens Neuhalfen <jens@neuhalfen.name>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/29c285b37828c76b2861b01cb9935d988a34b1da)
+*  docs: bump to 0.0.4; add Jens as author & (C) (/Jens Neuhalfen <jens@neuhalfen.name>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/6e4d77211926e47047f7cd016bad934218b5d96e)
+*  build: .gitignore scratch notes file (/Jens Neuhalfen <jens@neuhalfen.name>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/5004496c063ec48083ee48689ed4a2dd361c69ef)
+
+
+## v0.0.3 (2023-01-09)
+
+*  ignore .elc files for git (/triplem <160079+triplem@users.noreply.github.com>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/d374f1818d26b0f6cfe2541100ca098f2ccabf97)
+*  chore: resolve comments in melpa PR (/May, Markus <mmay@conet.de>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/6f7f0cc0d682f66d11f7fac4fa5c1e79904232da)
+
+
+## v0.0.2 (2023-01-02)
+
+*  minor fixes for melpa preparation (/triplem <160079+triplem@users.noreply.github.com>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/7df0cad9b998f9bb4fb9a82fd4a97a1acb1889aa)
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,30 +12,30 @@ Switch from path based key lookup where the caller needs to know the whole path 
 
 ### Changes
 
-*  Add Melpa Badge (/Markus M. May <160079+triplem@users.noreply.github.com>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/c9f7dc4da6178ca122e488e9ea07f20ccd29d87e)
-*  fix: correctly handle not found secrets (/Jens Neuhalfen <jens@neuhalfen.name>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/9cd22a0dc183226d57677358c6782a4c769111c6)
-*  feat: use dedicated *gopass* buffer for debugging (/Jens Neuhalfen <jens@neuhalfen.name>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/b5503f95235ff22b9858211b1605eda58011e12a)
-*  fix: actually return nil when gopass is not found (/Jens Neuhalfen <jens@neuhalfen.name>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/065dea9153a559729ac82eded30d97cfe7510901)
-*  fix: actually return the password.. (/Jens Neuhalfen <jens@neuhalfen.name>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/52440313e7fbc7baa7efb0dc6d2d0a85efc29c7f)
-*  feat: add fn to find all candidates for the query (/Jens Neuhalfen <jens@neuhalfen.name>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/40397df97b47968b2822daaa1b15ecdf866ecf93)
-*  feat: add parser for secrets to extract username (/Jens Neuhalfen <jens@neuhalfen.name>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/e4fe58d1267635555e694854dfd748f86911a164)
-*  feat(get-secret): extract fallback user from path (/Jens Neuhalfen <jens@neuhalfen.name>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/1a164ae0c8d908330a45fa548d02b1173e2d3786)
-*  feat: switch to a search based approach (/Jens Neuhalfen <jens@neuhalfen.name>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/13ffb7b26617799e82a826c01933484455851b04)
-*  feat: add changelog builder (/Jens Neuhalfen <jens@neuhalfen.name>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/565d4d40c29b0e803284c3f2e81bab4a49635237)
-*  feat: remove now unused `...-construct-query-path` (/Jens Neuhalfen <jens@neuhalfen.name>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/cab5207a188e5224c6131ba3ffbca6064cc0a53d)
-*  fix: respect auth-source-gopass-path-separator (/Jens Neuhalfen <jens@neuhalfen.name>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/29c285b37828c76b2861b01cb9935d988a34b1da)
-*  docs: bump to 0.0.4; add Jens as author & (C) (/Jens Neuhalfen <jens@neuhalfen.name>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/6e4d77211926e47047f7cd016bad934218b5d96e)
-*  build: .gitignore scratch notes file (/Jens Neuhalfen <jens@neuhalfen.name>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/5004496c063ec48083ee48689ed4a2dd361c69ef)
+*  Add Melpa Badge (*Markus M. May <160079+triplem@users.noreply.github.com>*) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/c9f7dc4da6178ca122e488e9ea07f20ccd29d87e)
+*  fix: correctly handle not found secrets (*Jens Neuhalfen <jens@neuhalfen.name>*) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/9cd22a0dc183226d57677358c6782a4c769111c6)
+*  feat: use dedicated *gopass* buffer for debugging (*Jens Neuhalfen <jens@neuhalfen.name>*) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/b5503f95235ff22b9858211b1605eda58011e12a)
+*  fix: actually return nil when gopass is not found (*Jens Neuhalfen <jens@neuhalfen.name>*) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/065dea9153a559729ac82eded30d97cfe7510901)
+*  fix: actually return the password.. (*Jens Neuhalfen <jens@neuhalfen.name>*) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/52440313e7fbc7baa7efb0dc6d2d0a85efc29c7f)
+*  feat: add fn to find all candidates for the query (*Jens Neuhalfen <jens@neuhalfen.name>*) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/40397df97b47968b2822daaa1b15ecdf866ecf93)
+*  feat: add parser for secrets to extract username (*Jens Neuhalfen <jens@neuhalfen.name>*) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/e4fe58d1267635555e694854dfd748f86911a164)
+*  feat(get-secret): extract fallback user from path (*Jens Neuhalfen <jens@neuhalfen.name>*) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/1a164ae0c8d908330a45fa548d02b1173e2d3786)
+*  feat: switch to a search based approach (*Jens Neuhalfen <jens@neuhalfen.name>*) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/13ffb7b26617799e82a826c01933484455851b04)
+*  feat: add changelog builder (*Jens Neuhalfen <jens@neuhalfen.name>*) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/565d4d40c29b0e803284c3f2e81bab4a49635237)
+*  feat: remove now unused `...-construct-query-path` (*Jens Neuhalfen <jens@neuhalfen.name>*) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/cab5207a188e5224c6131ba3ffbca6064cc0a53d)
+*  fix: respect auth-source-gopass-path-separator (*Jens Neuhalfen <jens@neuhalfen.name>*) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/29c285b37828c76b2861b01cb9935d988a34b1da)
+*  docs: bump to 0.0.4; add Jens as author & (C) (*Jens Neuhalfen <jens@neuhalfen.name>*) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/6e4d77211926e47047f7cd016bad934218b5d96e)
+*  build: .gitignore scratch notes file (*Jens Neuhalfen <jens@neuhalfen.name>*) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/5004496c063ec48083ee48689ed4a2dd361c69ef)
 
 
 ## v0.0.3 (2023-01-09)
 
-*  ignore .elc files for git (/triplem <160079+triplem@users.noreply.github.com>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/d374f1818d26b0f6cfe2541100ca098f2ccabf97)
-*  chore: resolve comments in melpa PR (/May, Markus <mmay@conet.de>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/6f7f0cc0d682f66d11f7fac4fa5c1e79904232da)
+*  ignore .elc files for git (*triplem <160079+triplem@users.noreply.github.com>*) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/d374f1818d26b0f6cfe2541100ca098f2ccabf97)
+*  chore: resolve comments in melpa PR (*May, Markus <mmay@conet.de>*) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/6f7f0cc0d682f66d11f7fac4fa5c1e79904232da)
 
 
 ## v0.0.2 (2023-01-02)
 
-*  minor fixes for melpa preparation (/triplem <160079+triplem@users.noreply.github.com>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/7df0cad9b998f9bb4fb9a82fd4a97a1acb1889aa)
+*  minor fixes for melpa preparation (*triplem <160079+triplem@users.noreply.github.com>*) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/7df0cad9b998f9bb4fb9a82fd4a97a1acb1889aa)
 
 

--- a/README.org
+++ b/README.org
@@ -1,7 +1,7 @@
 * Auth-Source-Gopass Emacs Package
 
 [[https://www.gnu.org/licenses/gpl-3.0][https://img.shields.io/badge/License-GPL%20v3-blue.svg]]
-[[http://melpa.org/#/auth-source-gopass][http://melpa.org/packages/auth-source-gopass-badge.svg]]
+[[http://melpa.org/#/auth-source-gopass][http://melpa.org/packages/auth-source-gopass-badge.svg]] (v. 0.0.3)
 
 This package provides [[https://www.gopass.pw/][gopass - the team password manager]] as an auth-source for emacs. This could be used with packages like eg. smtpmail to provide passwords for the smtp-user. It is a drop-in replacement for the default auth-info source.
 

--- a/README.org
+++ b/README.org
@@ -28,18 +28,3 @@ This package provides some parameters as well as a function, which can be custom
 
 - -auth-source-gopass-executable- :: Default value "gopass"
   Executable used for gopass.
-
-- -auth-source-gopass-construct-query-path- :: Default value 'auth-source-gopass--gopass-construct-entry-path
-  Function to construct the query path in the gopass store.
-
-  #+BEGIN_SRC elisp
-  (defun auth-source-gopass--gopass-construct-entry-path (_backend _type host user _port)
-  "Construct the full entry-path for the gopass entry grom HOST and USER.
-   Usually starting with the auth-source-gopass-path-prefix, followed by host
-   and user, separated by the auth-source-gopass-path-separator."
-  (mapconcat 'identity (list auth-source-gopass-path-prefix
-                             host
-                             user) auth-source-gopass-path-separator))
-  #+END_SRC
-
-  This function could be overwritten to construct the query path to your personal structure.

--- a/auth-source-gopass.el
+++ b/auth-source-gopass.el
@@ -48,7 +48,11 @@
       (let ((buf (get-buffer-create "*gopass*" t)))
         (with-current-buffer buf
           (erase-buffer)
-          (let* ((regex (format "%s.*%s.*%s" (or auth-source-gopass-path-prefix "") (or host "") (or user "")))
+          (let* ((regex (format "%s.*%s.*%s.*%s"
+                                (or auth-source-gopass-path-prefix "")
+                                (or host "")
+                                auth-source-gopass-path-separator
+                                (or user "")))
                  (gopass-exit-status (call-process auth-source-gopass-executable
                                                    nil
                                                    (current-buffer)
@@ -97,9 +101,9 @@ The value for user will be parsed from the SECRET, if possible. Fallback is USER
 (defun auth-source-gopass--get-user-from-path (path)
   "Get the user from PATH.
  a/b/c -> c and a/b/ -> nil.-"
-  (let ((match (string-match (rx "/"
-                                 (group (one-or-more (not "/")))
-                                 eol)
+  (let ((match (string-match (rx-to-string `(: ,auth-source-gopass-path-separator
+                                             (group (one-or-more (not ,auth-source-gopass-path-separator)))
+                                             eol))
                              path)))
     (if match
         (substring path (+ 1 match))

--- a/auth-source-gopass.el
+++ b/auth-source-gopass.el
@@ -74,9 +74,10 @@ SPEC, BACKEND, TYPE, HOST, USER and PORT are required by auth-source."
 
             (if  (not (= 0 gopass-exit-status))
                 nil ;; keep the buffer content for diagnosis
-              (list (list :user user
-                          :secret (buffer-string)))
-              (erase-buffer)))))
+              (let ((secret (buffer-string)))
+                (erase-buffer)
+                (list (list :user user
+                            :secret secret)))))))
     ;; If not executable was found, return nil and show a warning
     (warn "`auth-source-gopass': Could not find executable '%s' to query gopass" auth-source-gopass-executable)
     nil))

--- a/auth-source-gopass.el
+++ b/auth-source-gopass.el
@@ -41,18 +41,6 @@
   :type 'string
   :group 'auth-source-gopass)
 
-(defcustom auth-source-gopass-construct-query-path 'auth-source-gopass--gopass-construct-query-path
-  "Function to construct the query path in the gopass store."
-  :type 'function
-  :group 'auth-source-gopass)
-
-(defun auth-source-gopass--gopass-construct-query-path (_backend _type host user _port)
-  "Construct the full entry-path for the gopass entry grom HOST and USER.
-Usually starting with the `auth-source-gopass-path-prefix', followed by host
-and user, separated by the `auth-source-gopass-path-separator'."
-  (mapconcat #'identity (list auth-source-gopass-path-prefix
-                              host
-                              user) auth-source-gopass-path-separator))
 
 (defun  auth-source-gopass--find-candidates  (host user)
   "Run `gopass find' to find a list of candidate paths for the query HOST USER."

--- a/auth-source-gopass.el
+++ b/auth-source-gopass.el
@@ -78,7 +78,8 @@ SPEC, BACKEND, TYPE, HOST, USER and PORT are required by auth-source."
                           :secret (buffer-string)))
               (erase-buffer)))))
     ;; If not executable was found, return nil and show a warning
-    (warn "`auth-source-gopass': Could not find executable '%s' to query gopass" auth-source-gopass-executable)))
+    (warn "`auth-source-gopass': Could not find executable '%s' to query gopass" auth-source-gopass-executable)
+    nil))
 
 ;;;###autoload
 (defun auth-source-gopass-enable ()

--- a/auth-source-gopass.el
+++ b/auth-source-gopass.el
@@ -1,15 +1,16 @@
 ;;; auth-source-gopass.el --- Gopass integration for auth-source -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2022 Markus M. May
+;; Copyright (C) 2022 Markus M. May; 2025 Jens Neuhalfen
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 
-;; Author: Markus M. May <mmay@javafreedom.org>
+;; Author: Jens Neuhalfen <jens@neuhalfen.name> [0.0.4]
+;;         Markus M. May <mmay@javafreedom.org> [till 0.0.3]
 ;; Created: 31 December 2022
 ;; URL: https://github.com/
 
 ;; Package-Requires: ((emacs "29.1"))
 
-;; Version: 0.0.3
+;; Version: 0.0.4
 
 ;;; Commentary:
 ;; This package adds gopass support to auth-source by calling

--- a/changelog-builder.sh
+++ b/changelog-builder.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+echo "# CHANGELOG for auth-source-gopass"
+echo ""
+echo "_newest tag first, each tag sorted in chronological order (oldest first)_"
+echo
+
+previous_tag=0
+for current_tag in HEAD $(git tag --sort=-creatordate)
+do
+
+if [ "$previous_tag" != 0 ];then
+    tag_date=$(git log -1 --pretty=format:'%ad' --date=short ${previous_tag})
+    printf "## ${previous_tag} (${tag_date})\n\n"
+    git log ${current_tag}...${previous_tag} --pretty=format:'*  %s (/%aN <%ae>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/%H)' --reverse | grep -v Merge
+    printf "\n\n"
+fi
+previous_tag=${current_tag}
+done

--- a/changelog-builder.sh
+++ b/changelog-builder.sh
@@ -12,7 +12,7 @@ do
 if [ "$previous_tag" != 0 ];then
     tag_date=$(git log -1 --pretty=format:'%ad' --date=short ${previous_tag})
     printf "## ${previous_tag} (${tag_date})\n\n"
-    git log ${current_tag}...${previous_tag} --pretty=format:'*  %s (/%aN <%ae>/) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/%H)' --reverse | grep -v Merge
+    git log ${current_tag}...${previous_tag} --pretty=format:'*  %s (*%aN <%ae>*) [View](https://git.convex-hull.org/jens/P018_auth_sources_gopass/commit/%H)' --reverse | grep -v Merge
     printf "\n\n"
 fi
 previous_tag=${current_tag}


### PR DESCRIPTION
Switch from path based key lookup where the caller needs to know the whole path to a search based workflow.

Breaking Changes
------------------

- `auth-source-gopass-construct-query-path` removed: this is now done by searching
- The `user` is taken from the gopass secret, the secret's path, or the passed parameter of the user (in this order). Before it always was the passed in parameter.
- Switching to use `gopass find` may find more secrets. E.g. The query for the user `name` will now also find the users `myname` and `misnamer`
